### PR TITLE
add catalog-info.yaml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ references:
   environments:
     tmp: &TEST_RESULTS_PATH /tmp/test-results
 
-environment: &ENVIRONMENT
+environment:
   TEST_RESULTS: "/tmp/test-results"
 
 jobs:
@@ -26,7 +26,7 @@ jobs:
       - go/load-cache
       - go/mod-download
       - go/save-cache
-      - run: 
+      - run:
           name: Run go format
           command: |
             files=$(go fmt ./...)
@@ -35,8 +35,8 @@ jobs:
               echo "$files"
               exit 1
             fi
-      - run: 
-          name: Run tests with gotestsum 
+      - run:
+          name: Run tests with gotestsum
           command: |
             PACKAGE_NAMES=$(go list ./...)
             gotestsum --format=short-verbose --junitfile $TEST_RESULTS/go-retryablyhttp/gotestsum-report.xml -- $PACKAGE_NAMES
@@ -44,6 +44,7 @@ jobs:
           path: *TEST_RESULTS_PATH
       - store_artifacts:
           path: *TEST_RESULTS_PATH
+      - run: ../ci-scripts/circleci/catalog-sync $CATAPULT_URL $CATAPULT_USER $CATAPULT_PASS go-retryablehttp utility
 
 workflows:
   go-retryablehttp:

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,11 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: go-retryablehttp
+  description: Retryable HTTP client in Go
+  owner: unknown
+spec:
+  type: unknown
+  lifecycle: production
+  owner: unknown
+  system: Clever


### PR DESCRIPTION
# JIRA
https://clever.atlassian.net/browse/INFRANG-7610


# Overview
<https://clever.atlassian.net/browse/INFRANG-7067> missed a few repos. Specifically repos which are forks of other repos.

We want track every single repo in backstage. Currently only repos with an `launch` directory i.e applications are tracked in backstage which this PR aims to change.

To track non applications repo we are adding a catalog-info.yaml file. In this PR I am adding that file via a microplane script so it 
- sets type to "unknown". In 2026 we will do an EWI to update all repos to have a type like "library", "cli", "docs", etc
- owner is determined via README or CODEOWNERS using best effort. In 2026 we will do an EWI to assign owners for unknowns and delete/archive repos that are not in use and have no owners
- description is same as the github repo description.

Note that some repos don't have a circle-ci project associated with them so those repos will get synced onced a week using `catalog-sync-all` worker instead of being synced on every merge.

## Testing
As long as CI is passing it is safe to merge these PRs but make sure to check that circleci is actually one of the checks because a misconfigured ci file ends up not getting reported instead of reporting an error

# Rollout
Infra to merge the PR once CI is passing and approved.
